### PR TITLE
Use cwd when no path given to pkgConf(key) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,6 +980,8 @@ $ node test.js
   '$0': 'test.js' }
 ```
 
+Note that a configuration object may extend from a JSON file using the `"extends"` property. When doing so, the `"extends"` value should be a path (relative or absolute) to the extended JSON file.
+
 <a name="conflicts"></a>.conflicts(x, y)
 ----------------------------------------------
 
@@ -1648,6 +1650,8 @@ as a configuration object.
 
 `cwd` can optionally be provided, the package.json will be read
 from this location.
+
+Note that a configuration stanza in package.json may extend from an identically keyed stanza in another package.json file using the `"extends"` property. When doing so, the `"extends"` value should be a path (relative or absolute) to the extended package.json file.
 
 .recommendCommands()
 ---------------------------

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -1440,6 +1440,13 @@ describe('yargs dsl tests', function () {
       argv.a.should.equal(80)
       argv.b.should.equals('riffiwobbles')
     })
+
+    it('should apply extended configurations from cwd when no path is given', function () {
+      var argv = yargs('', 'test/fixtures/extends/packageA').pkgConf('foo').argv
+
+      argv.a.should.equal(80)
+      argv.b.should.equals('riffiwobbles')
+    })
   })
 
   describe('skipValidation', function () {

--- a/yargs.js
+++ b/yargs.js
@@ -472,11 +472,14 @@ function Yargs (processArgs, cwd, parentRequire) {
   self.pkgConf = function (key, path) {
     argsert('<string> [string]', [key, path], arguments.length)
     var conf = null
-    var obj = pkgUp(path)
+    // prefer cwd to require-main-filename in this method
+    // since we're looking for e.g. "nyc" config in nyc consumer
+    // rather than "yargs" config in nyc (where nyc is the main filename)
+    var obj = pkgUp(path || cwd)
 
     // If an object exists in the key, add it to options.configObjects
     if (obj[key] && typeof obj[key] === 'object') {
-      conf = applyExtends(obj[key], path, key)
+      conf = applyExtends(obj[key], path || cwd, key)
       options.configObjects = (options.configObjects || []).concat(conf)
     }
 


### PR DESCRIPTION
Addresses the concerns with yargs/yargs#779 [expressed here](https://github.com/yargs/yargs/pull/779#discussion_r102094576), which falls back to using cwd (as defined by the yargs instance) when no path is given to the `.pkgConf(key, path)` method.

Also added a note to README about using `"extends"` in config objects.